### PR TITLE
für DB2 Exception EntityGenerator verhindern

### DIFF
--- a/src/main/java/pm/pride/AbstractResourceAccessor.java
+++ b/src/main/java/pm/pride/AbstractResourceAccessor.java
@@ -145,7 +145,7 @@ public abstract class AbstractResourceAccessor implements ResourceAccessor {
 			    return new SimpleDateFormat("'to_date('''yyyy-MM-dd''',''YYYY-MM-DD'')'");
 			if(dbType.equalsIgnoreCase(DBType.SQLITE))
 				return new UnixTimeDateFormat();
-			else if(dbType.equalsIgnoreCase(DBType.CLOUDSCAPE))
+			else if(dbType.equalsIgnoreCase(DBType.CLOUDSCAPE) || dbType.equalsIgnoreCase(DBType.DB2))
 				return new SimpleDateFormat("''yyyy-MM-dd''");
 		}
 		return null;
@@ -159,7 +159,7 @@ public abstract class AbstractResourceAccessor implements ResourceAccessor {
 			    return new SimpleDateFormat("'to_timestamp('''yyyy-MM-dd HH:mm:ss.SSS''',''YYYY-MM-DD HH24:MI:SS.FF'')'");
 			if(dbType.equalsIgnoreCase(DBType.SQLITE))
 				return new UnixTimeDateFormat();
-			else if(dbType.equalsIgnoreCase(DBType.CLOUDSCAPE))
+			else if(dbType.equalsIgnoreCase(DBType.CLOUDSCAPE) || dbType.equalsIgnoreCase(DBType.DB2))
 				return new SimpleDateFormat("''yyyy-MM-dd HH:mm:ss.SSS''");
 		}
 		return null;

--- a/src/main/java/pm/pride/util/generator/EntityGenerator.java
+++ b/src/main/java/pm/pride/util/generator/EntityGenerator.java
@@ -159,6 +159,7 @@ public class EntityGenerator {
 			writeGetMethods(tableDesc, className, baseClassName, generationType, buffer);
 			writeSetMethods(tableDesc, className, baseClassName, generationType, buffer);
 			writeFooter(tableDesc, className, baseClassName, generationType, buffer);
+					  con.rollback();
             con.close();
             con = null;
 		} else {


### PR DESCRIPTION
Für DB2 muss im EntityGenerator vor dem Connection.close(), die Transaktion zurückgerollt werden.

Anscheinend öffnet DB2 bereits lesenden Zugriffen eine Transaktion, die das schließen der Connection verhindert:

Exception in thread "main" com.ibm.db2.jcc.am.SqlException: [jcc][t4][10251][10308][4.22.29] java.sql.Connection.close() wurde angefordert, während eine Transaktion über die Verbindung ausgeführt wird.
Die Transaktion bleibt aktiv. Die Verbindung kann nicht geschlossen werden. ERRORCODE=-4471, SQLSTATE=null
	at com.ibm.db2.jcc.am.ld.a(ld.java:794)
	at com.ibm.db2.jcc.am.ld.a(ld.java:66)
	at com.ibm.db2.jcc.am.ld.a(ld.java:133)
	at com.ibm.db2.jcc.am.Connection.checkForTransactionInProgress(Connection.java:1473)
	at com.ibm.db2.jcc.t4.b.checkForTransactionInProgress(b.java:7406)
	at com.ibm.db2.jcc.am.Connection.closeResourcesX(Connection.java:1496)
	at com.ibm.db2.jcc.am.Connection.closeX(Connection.java:1482)
	at com.ibm.db2.jcc.am.Connection.close(Connection.java:1459)
	at pm.pride.util.generator.EntityGenerator.create(EntityGenerator.java:162)
	at pm.pride.util.generator.EntityGenerator.createAndPrint(EntityGenerator.java:611)
	at pm.pride.util.generator.EntityGenerator.main(EntityGenerator.java:615)
